### PR TITLE
use alter-var-root instead of spitting to .lein-env

### DIFF
--- a/src/danielsz/boot_environ.clj
+++ b/src/danielsz/boot_environ.clj
@@ -9,6 +9,5 @@
 
 (core/deftask environ [e env FOO=BAR {kw edn} "The environment map"]
   (core/with-pre-wrap fileset
-    (boot.util/info (str "environment " env "\n"))
-    (spit env-file (pr-str env))
+    (alter-var-root #'environ.core/env merge env)
     fileset))

--- a/src/danielsz/boot_environ.clj
+++ b/src/danielsz/boot_environ.clj
@@ -9,5 +9,6 @@
 
 (core/deftask environ [e env FOO=BAR {kw edn} "The environment map"]
   (core/with-pre-wrap fileset
+    (boot.util/info (str "environment " env "\n"))
     (alter-var-root #'environ.core/env merge env)
     fileset))


### PR DESCRIPTION
this will ensure that environ.core/env will always contain the env info passed to the environ task
