### PR TITLE
make printing optional

### DIFF
--- a/src/danielsz/boot_environ.clj
+++ b/src/danielsz/boot_environ.clj
@@ -6,9 +6,10 @@
    [boot.util       :as util]
    [environ.core :as environ]))
 
-(core/deftask environ [e env FOO=BAR {kw edn} "The environment map"]
+(core/deftask environ [e env FOO=BAR {kw edn} "The environment map"
+                       v verbose     bool     "Print env map"]
   (fn [next-task]
     (fn [fileset]
-      (boot.util/info (str "environment " env "\n"))
+      (when verbose (boot.util/info (str "environment " env "\n")))
       (with-redefs [environ/env (merge environ/env env)]
         (next-task fileset)))))


### PR DESCRIPTION
I'm running into a case where printing throws a formatting exception because boot.util/info is trying to print something like  `{:x "%ABC"}`
